### PR TITLE
chore(trivy): throw on OS vulns only

### DIFF
--- a/actions/trivy-scan-image/action.yaml
+++ b/actions/trivy-scan-image/action.yaml
@@ -10,7 +10,10 @@ inputs:
   severity:
     description: "Trivy level of security"
     default: "CRITICAL"
-
+  vuln-type:
+    description: "Trivy type of vuln. ex: os,library"
+    default: "os"
+    
 runs:
   using: "composite"
   steps:
@@ -22,6 +25,7 @@ runs:
         exit-code: '1'
         timeout: "20m"
         format: 'table'
+        vuln-type: '${{ inputs.vuln-type }}' 
         # format: 'sarif'
         # output: 'trivy-results.sarif'
     


### PR DESCRIPTION
limit to criticals OS vulns only for the moment