### PR TITLE
fix(deactivate): make it silent

### DIFF
--- a/.github/workflows/use-ks-gh-deactivate.yaml
+++ b/.github/workflows/use-ks-gh-deactivate.yaml
@@ -88,7 +88,7 @@ jobs:
           KS_DEPLOY_WRITE_OUTPUT_FILE=${KS_DEPLOY_WRITE_OUTPUT_FILE:-"kontinuous-deployment-output.log"}
           if [ ! -f "$KS_DEPLOY_WRITE_OUTPUT_FILE" ]; then
             echo 'see previous steps to inspect full logs'
-            exit 1
+            exit 0
           fi
           cat $KS_DEPLOY_WRITE_OUTPUT_FILE
-          exit 1
+          exit 0

--- a/.github/workflows/use-ks-wh-deactivate.yaml
+++ b/.github/workflows/use-ks-wh-deactivate.yaml
@@ -88,7 +88,7 @@ jobs:
           KS_DEPLOY_WRITE_OUTPUT_FILE=${KS_DEPLOY_WRITE_OUTPUT_FILE:-"kontinuous-deployment-output.log"}
           if [ ! -f "$KS_DEPLOY_WRITE_OUTPUT_FILE" ]; then
             echo 'see previous steps to inspect full logs'
-            exit 1
+            exit 0
           fi
           cat $KS_DEPLOY_WRITE_OUTPUT_FILE
-          exit 1
+          exit 0


### PR DESCRIPTION
Having notifications about failed deactivate may be annoying. 

as this step is out of control from the end users, i think it should not report failures to them (and may be reported to us in sentry)

ex: https://github.com/SocialGouv/mda/actions/runs/5271833354/jobs/9533269464