### PR TITLE
feat(deploy): add inputs.kubeconfigContext

### DIFF
--- a/.github/workflows/use-ks-gh-manual.yaml
+++ b/.github/workflows/use-ks-gh-manual.yaml
@@ -19,6 +19,11 @@ on:
       kubeconfig:
         required: false
         type: string
+      kubeconfigContext:
+        required: false
+        type: string
+        description: "override kubeconfig context, default dev or prod according to environment"
+
     secrets:
       KUBECONFIG:
         required: true
@@ -38,6 +43,7 @@ jobs:
       - uses: socialgouv/kontinuous/.github/actions/deploy-via-github@v1
         with:
           kubeconfig: ${{ inputs.kubeconfig || secrets.KUBECONFIG }}
+          kubeconfigContext: ${{ inputs.kubeconfigContext }}
           chart: ${{ inputs.chart }}
           ignoreProjectTemplates: ${{ inputs.ignoreProjectTemplates }}
           environment: ${{ inputs.environment }}

--- a/.github/workflows/use-ks-gh-preproduction.yaml
+++ b/.github/workflows/use-ks-gh-preproduction.yaml
@@ -11,7 +11,10 @@ on:
       kubeconfig:
         required: false
         type: string
-    
+      kubeconfigContext:
+        required: false
+        type: string
+        description: "override kubeconfig context, default dev or prod according to environment"
 
 jobs:
   deploy:
@@ -42,6 +45,7 @@ jobs:
           notifyWebhookUrl: ${{ secrets.KS_NOTIFY_MATTERMOST_WEBHOOK_URL }}
           projectName: ${{ vars.KS_PROJECT_NAME }}
           ciNamespace: ${{ vars.KS_CI_NAMESPACE }}
+          kubeconfigContext: ${{ inputs.kubeconfigContext }} 
 
       - uses: socialgouv/workflows/actions/deployment-ending@v1
         id: deployment-ending

--- a/.github/workflows/use-ks-gh-production.yaml
+++ b/.github/workflows/use-ks-gh-production.yaml
@@ -11,6 +11,10 @@ on:
       kubeconfig:
         required: false
         type: string
+      kubeconfigContext:
+        required: false
+        type: string
+        description: "override kubeconfig context, default dev or prod according to environment"
 
 jobs:
   deploy:
@@ -41,6 +45,7 @@ jobs:
           notifyWebhookUrl: ${{ secrets.KS_NOTIFY_MATTERMOST_WEBHOOK_URL }}
           projectName: ${{ vars.KS_PROJECT_NAME }}
           ciNamespace: ${{ vars.KS_CI_NAMESPACE }}
+          kubeconfigContext: ${{ inputs.kubeconfigContext }}
 
       - uses: socialgouv/workflows/actions/deployment-ending@v1
         id: deployment-ending

--- a/.github/workflows/use-ks-gh-review-auto.yaml
+++ b/.github/workflows/use-ks-gh-review-auto.yaml
@@ -11,6 +11,10 @@ on:
       kubeconfig:
         required: false
         type: string
+      kubeconfigContext:
+        required: false
+        type: string
+        description: "override kubeconfig context, default dev or prod according to environment"
 
 jobs:
   deploy:
@@ -41,6 +45,7 @@ jobs:
           notifyWebhookUrl: ${{ secrets.KS_NOTIFY_MATTERMOST_WEBHOOK_URL }}
           projectName: ${{ vars.KS_PROJECT_NAME }}
           ciNamespace: ${{ vars.KS_CI_NAMESPACE }}
+          kubeconfigContext: ${{ inputs.kubeconfigContext }}
 
       - uses: socialgouv/workflows/actions/deployment-ending@v1
         id: deployment-ending

--- a/.github/workflows/use-ks-gh-review.yaml
+++ b/.github/workflows/use-ks-gh-review.yaml
@@ -11,6 +11,10 @@ on:
       kubeconfig:
         required: false
         type: string
+      kubeconfigContext:
+        required: false
+        type: string
+        description: "override kubeconfig context, default dev or prod according to environment"
 
 jobs:
   deploy:
@@ -41,6 +45,7 @@ jobs:
           notifyWebhookUrl: ${{ secrets.KS_NOTIFY_MATTERMOST_WEBHOOK_URL }}
           projectName: ${{ vars.KS_PROJECT_NAME }}
           ciNamespace: ${{ vars.KS_CI_NAMESPACE }}
+          kubeconfigContext: ${{ inputs.kubeconfigContext }}
 
       - uses: socialgouv/workflows/actions/deployment-ending@v1
         id: deployment-ending


### PR DESCRIPTION
Not sure if we'll have to manually specify the context or if it will be discovered via kontinuous config