### PR TITLE
fix(ci-cd): use token-bureau

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,13 +5,23 @@ on:
   push:
     branches: [master]
 
+permissions:
+  id-token: write  # Required for OIDC token generation
+
 jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
     steps:
+      - name: Get GitHub App Token
+        id: token
+        uses: SocialGouv/token-bureau@main
+        with:
+          token-bureau-url: https://token-bureau.fabrique.social.gouv.fr
+          audience: socialgouv
+
       - uses: socialgouv/workflows/actions/semantic-release@v1
         with:
-          github-token: ${{ secrets.SOCIALGROOVYBOT_BOTO_PAT }}
+          github-token: ${{ steps.token.outputs.token }}
           author-name: ${{ secrets.SOCIALGROOVYBOT_NAME }}
           author-email: ${{ secrets.SOCIALGROOVYBOT_EMAIL }}

--- a/.github/workflows/use-ks-gh-deactivate.yaml
+++ b/.github/workflows/use-ks-gh-deactivate.yaml
@@ -25,6 +25,9 @@ on:
       KS_NOTIFY_MATTERMOST_WEBHOOK_URL:
         required: false
 
+permissions:
+  id-token: write  # Required for OIDC token generation
+
 jobs:
   deploy:
     name: Deactivate Pipeline ♻️
@@ -71,12 +74,19 @@ jobs:
           env: ${{ steps.deployment-vars.outputs.deployment-name }}
           desc: Deployment was pruned
       
+      - name: Get GitHub App Token
+        id: token
+        uses: SocialGouv/token-bureau@main
+        with:
+          token-bureau-url: https://token-bureau.fabrique.social.gouv.fr
+          audience: socialgouv
+
       - name: Clean review sub environment
         uses: socialgouv/deployments@v1
         continue-on-error: true
         with:
           step: delete-env
-          token: ${{ secrets.SOCIALGROOVYBOT_BOTO_PAT }}
+          token: ${{ steps.token.outputs.token }}
           env: ${{ steps.deployment-vars.outputs.deployment-name }}
           desc: Environment was pruned
 

--- a/.github/workflows/use-ks-gh-preproduction.yaml
+++ b/.github/workflows/use-ks-gh-preproduction.yaml
@@ -15,6 +15,9 @@ on:
         required: false
         type: string
 
+permissions:
+  id-token: write  # Required for OIDC token generation
+
 jobs:
   deploy:
     name: 🐳 Deploy PreProd on Kubernetes
@@ -26,11 +29,18 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Get GitHub App Token
+        id: token
+        uses: SocialGouv/token-bureau@main
+        with:
+          token-bureau-url: https://token-bureau.fabrique.social.gouv.fr
+          audience: socialgouv
+
       - uses: socialgouv/workflows/actions/deployment-starting@v1
         id: deployment-starting
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          pat: ${{ secrets.SOCIALGROOVYBOT_BOTO_PAT }}
+          pat: ${{ steps.token.outputs.token }}
           environment-scope: preproduction
 
       - uses: socialgouv/kontinuous/.github/actions/deploy-via-github@v1
@@ -49,7 +59,7 @@ jobs:
       - uses: socialgouv/workflows/actions/deployment-ending@v1
         id: deployment-ending
         with:
-          pat: ${{ secrets.SOCIALGROOVYBOT_BOTO_PAT }}
+          pat: ${{ steps.token.outputs.token }}
           token: ${{ secrets.GITHUB_TOKEN }}
           deployment-id: ${{ steps.deployment-starting.outputs.deployment-id }}
           deployment-name:

--- a/.github/workflows/use-ks-gh-production.yaml
+++ b/.github/workflows/use-ks-gh-production.yaml
@@ -15,6 +15,9 @@ on:
         required: false
         type: string
 
+permissions:
+  id-token: write  # Required for OIDC token generation
+
 jobs:
   deploy:
     name: 🐳 Deploy Production on Kubernetes
@@ -26,11 +29,18 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Get GitHub App Token
+        id: token
+        uses: SocialGouv/token-bureau@main
+        with:
+          token-bureau-url: https://token-bureau.fabrique.social.gouv.fr
+          audience: socialgouv
+
       - uses: socialgouv/workflows/actions/deployment-starting@v1
         id: deployment-starting
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          pat: ${{ secrets.SOCIALGROOVYBOT_BOTO_PAT }}
+          pat: ${{ steps.token.outputs.token }}
           environment-scope: production
 
       - uses: socialgouv/kontinuous/.github/actions/deploy-via-github@v1
@@ -49,7 +59,7 @@ jobs:
       - uses: socialgouv/workflows/actions/deployment-ending@v1
         id: deployment-ending
         with:
-          pat: ${{ secrets.SOCIALGROOVYBOT_BOTO_PAT }}
+          pat: ${{ steps.token.outputs.token }}
           token: ${{ secrets.GITHUB_TOKEN }}
           deployment-id: ${{ steps.deployment-starting.outputs.deployment-id }}
           deployment-name:

--- a/.github/workflows/use-ks-gh-review-auto.yaml
+++ b/.github/workflows/use-ks-gh-review-auto.yaml
@@ -15,6 +15,9 @@ on:
         required: false
         type: string
 
+permissions:
+  id-token: write  # Required for OIDC token generation
+
 jobs:
   deploy:
     name: 🐳 Deploy Review on Kubernetes
@@ -26,11 +29,18 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Get GitHub App Token
+        id: token
+        uses: SocialGouv/token-bureau@main
+        with:
+          token-bureau-url: https://token-bureau.fabrique.social.gouv.fr
+          audience: socialgouv
+
       - uses: socialgouv/workflows/actions/deployment-starting@v1
         id: deployment-starting
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          pat: ${{ secrets.SOCIALGROOVYBOT_BOTO_PAT }}
+          pat: ${{ steps.token.outputs.token }}
           environment-scope: review
 
       - uses: socialgouv/kontinuous/.github/actions/deploy-via-github@v1
@@ -49,7 +59,7 @@ jobs:
       - uses: socialgouv/workflows/actions/deployment-ending@v1
         id: deployment-ending
         with:
-          pat: ${{ secrets.SOCIALGROOVYBOT_BOTO_PAT }}
+          pat: ${{ steps.token.outputs.token }}
           token: ${{ secrets.GITHUB_TOKEN }}
           deployment-id: ${{ steps.deployment-starting.outputs.deployment-id }}
           deployment-name:

--- a/.github/workflows/use-ks-gh-review.yaml
+++ b/.github/workflows/use-ks-gh-review.yaml
@@ -15,6 +15,9 @@ on:
         required: false
         type: string
 
+permissions:
+  id-token: write  # Required for OIDC token generation
+
 jobs:
   deploy:
     name: 🐳 Deploy Review on Kubernetes
@@ -26,11 +29,18 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Get GitHub App Token
+        id: token
+        uses: SocialGouv/token-bureau@main
+        with:
+          token-bureau-url: https://token-bureau.fabrique.social.gouv.fr
+          audience: socialgouv
+
       - uses: socialgouv/workflows/actions/deployment-starting@v1
         id: deployment-starting
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          pat: ${{ secrets.SOCIALGROOVYBOT_BOTO_PAT }}
+          pat: ${{ steps.token.outputs.token }}
           environment-scope: review
 
       - uses: socialgouv/kontinuous/.github/actions/deploy-via-github@v1
@@ -49,7 +59,7 @@ jobs:
       - uses: socialgouv/workflows/actions/deployment-ending@v1
         id: deployment-ending
         with:
-          pat: ${{ secrets.SOCIALGROOVYBOT_BOTO_PAT }}
+          pat: ${{ steps.token.outputs.token }}
           token: ${{ secrets.GITHUB_TOKEN }}
           deployment-id: ${{ steps.deployment-starting.outputs.deployment-id }}
           deployment-name:

--- a/.github/workflows/use-ks-gh-with-env-deactivate.yaml
+++ b/.github/workflows/use-ks-gh-with-env-deactivate.yaml
@@ -25,6 +25,9 @@ on:
       KS_NOTIFY_MATTERMOST_WEBHOOK_URL:
         required: false
 
+permissions:
+  id-token: write  # Required for OIDC token generation
+
 jobs:
   deploy:
     name: Deactivate Pipeline ♻️
@@ -71,12 +74,19 @@ jobs:
           env: ${{ steps.deployment-vars.outputs.deployment-name }}
           desc: Deployment was pruned
       
+      - name: Get GitHub App Token
+        id: token
+        uses: SocialGouv/token-bureau@main
+        with:
+          token-bureau-url: https://token-bureau.fabrique.social.gouv.fr
+          audience: socialgouv
+
       - name: Clean review sub environment
         uses: socialgouv/deployments@v1
         continue-on-error: true
         with:
           step: delete-env
-          token: ${{ secrets.SOCIALGROOVYBOT_BOTO_PAT }}
+          token: ${{ steps.token.outputs.token }}
           env: ${{ steps.deployment-vars.outputs.deployment-name }}
           desc: Environment was pruned
 

--- a/.github/workflows/use-ks-gh-with-env-preproduction.yaml
+++ b/.github/workflows/use-ks-gh-with-env-preproduction.yaml
@@ -15,6 +15,9 @@ on:
         required: false
         type: string
 
+permissions:
+  id-token: write  # Required for OIDC token generation
+
 jobs:
   deploy:
     name: 🐳 Deploy PreProd on Kubernetes
@@ -26,11 +29,18 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Get GitHub App Token
+        id: token
+        uses: SocialGouv/token-bureau@main
+        with:
+          token-bureau-url: https://token-bureau.fabrique.social.gouv.fr
+          audience: socialgouv
+
       - uses: socialgouv/workflows/actions/deployment-starting@v1
         id: deployment-starting
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          pat: ${{ secrets.SOCIALGROOVYBOT_BOTO_PAT }}
+          pat: ${{ steps.token.outputs.token }}
           environment-scope: preproduction
           github-env-enabled: true
 
@@ -50,7 +60,7 @@ jobs:
       - uses: socialgouv/workflows/actions/deployment-ending@v1
         id: deployment-ending
         with:
-          pat: ${{ secrets.SOCIALGROOVYBOT_BOTO_PAT }}
+          pat: ${{ steps.token.outputs.token }}
           token: ${{ secrets.GITHUB_TOKEN }}
           deployment-id: ${{ steps.deployment-starting.outputs.deployment-id }}
           deployment-name:

--- a/.github/workflows/use-ks-gh-with-env-production.yaml
+++ b/.github/workflows/use-ks-gh-with-env-production.yaml
@@ -15,6 +15,9 @@ on:
         required: false
         type: string
 
+permissions:
+  id-token: write  # Required for OIDC token generation
+
 jobs:
   deploy:
     name: 🐳 Deploy Production on Kubernetes
@@ -26,11 +29,18 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Get GitHub App Token
+        id: token
+        uses: SocialGouv/token-bureau@main
+        with:
+          token-bureau-url: https://token-bureau.fabrique.social.gouv.fr
+          audience: socialgouv
+
       - uses: socialgouv/workflows/actions/deployment-starting@v1
         id: deployment-starting
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          pat: ${{ secrets.SOCIALGROOVYBOT_BOTO_PAT }}
+          pat: ${{ steps.token.outputs.token }}
           environment-scope: production
           github-env-enabled: true
 
@@ -50,7 +60,7 @@ jobs:
       - uses: socialgouv/workflows/actions/deployment-ending@v1
         id: deployment-ending
         with:
-          pat: ${{ secrets.SOCIALGROOVYBOT_BOTO_PAT }}
+          pat: ${{ steps.token.outputs.token }}
           token: ${{ secrets.GITHUB_TOKEN }}
           deployment-id: ${{ steps.deployment-starting.outputs.deployment-id }}
           deployment-name:

--- a/.github/workflows/use-ks-gh-with-env-review-auto.yaml
+++ b/.github/workflows/use-ks-gh-with-env-review-auto.yaml
@@ -15,6 +15,9 @@ on:
         required: false
         type: string
 
+permissions:
+  id-token: write  # Required for OIDC token generation
+
 jobs:
   deploy:
     name: 🐳 Deploy Review on Kubernetes
@@ -26,11 +29,18 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Get GitHub App Token
+        id: token
+        uses: SocialGouv/token-bureau@main
+        with:
+          token-bureau-url: https://token-bureau.fabrique.social.gouv.fr
+          audience: socialgouv
+
       - uses: socialgouv/workflows/actions/deployment-starting@v1
         id: deployment-starting
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          pat: ${{ secrets.SOCIALGROOVYBOT_BOTO_PAT }}
+          pat: ${{ steps.token.outputs.token }}
           environment-scope: review
           github-env-enabled: true
 
@@ -50,7 +60,7 @@ jobs:
       - uses: socialgouv/workflows/actions/deployment-ending@v1
         id: deployment-ending
         with:
-          pat: ${{ secrets.SOCIALGROOVYBOT_BOTO_PAT }}
+          pat: ${{ steps.token.outputs.token }}
           token: ${{ secrets.GITHUB_TOKEN }}
           deployment-id: ${{ steps.deployment-starting.outputs.deployment-id }}
           deployment-name:

--- a/.github/workflows/use-ks-gh-with-env-review.yaml
+++ b/.github/workflows/use-ks-gh-with-env-review.yaml
@@ -15,6 +15,9 @@ on:
         required: false
         type: string
 
+permissions:
+  id-token: write  # Required for OIDC token generation
+
 jobs:
   deploy:
     name: 🐳 Deploy Review on Kubernetes
@@ -26,11 +29,18 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Get GitHub App Token
+        id: token
+        uses: SocialGouv/token-bureau@main
+        with:
+          token-bureau-url: https://token-bureau.fabrique.social.gouv.fr
+          audience: socialgouv
+
       - uses: socialgouv/workflows/actions/deployment-starting@v1
         id: deployment-starting
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          pat: ${{ secrets.SOCIALGROOVYBOT_BOTO_PAT }}
+          pat: ${{ steps.token.outputs.token }}
           environment-scope: review
           github-env-enabled: true
 
@@ -50,7 +60,7 @@ jobs:
       - uses: socialgouv/workflows/actions/deployment-ending@v1
         id: deployment-ending
         with:
-          pat: ${{ secrets.SOCIALGROOVYBOT_BOTO_PAT }}
+          pat: ${{ steps.token.outputs.token }}
           token: ${{ secrets.GITHUB_TOKEN }}
           deployment-id: ${{ steps.deployment-starting.outputs.deployment-id }}
           deployment-name:

--- a/.github/workflows/use-ks-wh-deactivate.yaml
+++ b/.github/workflows/use-ks-wh-deactivate.yaml
@@ -22,6 +22,9 @@ on:
       KUBEWEBHOOK_TOKEN:
         required: true
 
+permissions:
+  id-token: write  # Required for OIDC token generation
+
 jobs:
   deploy:
     name: Deactivate Pipeline ♻️
@@ -64,12 +67,19 @@ jobs:
           env: ${{ steps.deployment-vars.outputs.deployment-name }}
           desc: Deployment was pruned
       
+      - name: Get GitHub App Token
+        id: token
+        uses: SocialGouv/token-bureau@main
+        with:
+          token-bureau-url: https://token-bureau.fabrique.social.gouv.fr
+          audience: socialgouv
+
       - name: Clean review sub environment
         uses: socialgouv/deployments@v1
         continue-on-error: true
         with:
           step: delete-env
-          token: ${{ secrets.SOCIALGROOVYBOT_BOTO_PAT }}
+          token: ${{ steps.token.outputs.token }}
           env: ${{ steps.deployment-vars.outputs.deployment-name }}
           desc: Environment was pruned
 

--- a/.github/workflows/use-ks-wh-preproduction.yaml
+++ b/.github/workflows/use-ks-wh-preproduction.yaml
@@ -12,6 +12,9 @@ on:
       KUBEWEBHOOK_TOKEN:
         required: true
 
+permissions:
+  id-token: write  # Required for OIDC token generation
+
 jobs:
   deploy:
     name: 🐳 Deploy PreProd on Kubernetes
@@ -20,11 +23,18 @@ jobs:
     outputs:
       manifests-images: ${{ steps.deployment-ending.outputs.manifests-images }}
     steps:
+      - name: Get GitHub App Token
+        id: token
+        uses: SocialGouv/token-bureau@main
+        with:
+          token-bureau-url: https://token-bureau.fabrique.social.gouv.fr
+          audience: socialgouv
+
       - uses: socialgouv/workflows/actions/deployment-starting@v1
         id: deployment-starting
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          pat: ${{ secrets.SOCIALGROOVYBOT_BOTO_PAT }}
+          pat: ${{ steps.token.outputs.token }}
           environment-scope: preproduction
 
       - uses: socialgouv/kontinuous/.github/actions/deploy-via-webhook@v1
@@ -42,7 +52,7 @@ jobs:
       - uses: socialgouv/workflows/actions/deployment-ending@v1
         id: deployment-ending
         with:
-          pat: ${{ secrets.SOCIALGROOVYBOT_BOTO_PAT }}
+          pat: ${{ steps.token.outputs.token }}
           token: ${{ secrets.GITHUB_TOKEN }}
           deployment-id: ${{ steps.deployment-starting.outputs.deployment-id }}
           deployment-name:

--- a/.github/workflows/use-ks-wh-production.yaml
+++ b/.github/workflows/use-ks-wh-production.yaml
@@ -12,6 +12,9 @@ on:
       KUBEWEBHOOK_TOKEN:
         required: true
 
+permissions:
+  id-token: write  # Required for OIDC token generation
+
 jobs:
   deploy:
     name: 🐳 Deploy Production on Kubernetes
@@ -20,11 +23,18 @@ jobs:
     outputs:
       manifests-images: ${{ steps.deployment-ending.outputs.manifests-images }}
     steps:
+      - name: Get GitHub App Token
+        id: token
+        uses: SocialGouv/token-bureau@main
+        with:
+          token-bureau-url: https://token-bureau.fabrique.social.gouv.fr
+          audience: socialgouv
+
       - uses: socialgouv/workflows/actions/deployment-starting@v1
         id: deployment-starting
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          pat: ${{ secrets.SOCIALGROOVYBOT_BOTO_PAT }}
+          pat: ${{ steps.token.outputs.token }}
           environment-scope: production
 
       - uses: socialgouv/kontinuous/.github/actions/deploy-via-webhook@v1
@@ -42,7 +52,7 @@ jobs:
       - uses: socialgouv/workflows/actions/deployment-ending@v1
         id: deployment-ending
         with:
-          pat: ${{ secrets.SOCIALGROOVYBOT_BOTO_PAT }}
+          pat: ${{ steps.token.outputs.token }}
           token: ${{ secrets.GITHUB_TOKEN }}
           deployment-id: ${{ steps.deployment-starting.outputs.deployment-id }}
           deployment-name:

--- a/.github/workflows/use-ks-wh-review-auto.yaml
+++ b/.github/workflows/use-ks-wh-review-auto.yaml
@@ -12,6 +12,9 @@ on:
       KUBEWEBHOOK_TOKEN:
         required: true
 
+permissions:
+  id-token: write  # Required for OIDC token generation
+
 jobs:
   deploy:
     name: 🐳 Deploy Review on Kubernetes
@@ -20,11 +23,18 @@ jobs:
     outputs:
       manifests-images: ${{ steps.deployment-ending.outputs.manifests-images }}
     steps:
+      - name: Get GitHub App Token
+        id: token
+        uses: SocialGouv/token-bureau@main
+        with:
+          token-bureau-url: https://token-bureau.fabrique.social.gouv.fr
+          audience: socialgouv
+
       - uses: socialgouv/workflows/actions/deployment-starting@v1
         id: deployment-starting
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          pat: ${{ secrets.SOCIALGROOVYBOT_BOTO_PAT }}
+          pat: ${{ steps.token.outputs.token }}
           environment-scope: review
 
       - uses: socialgouv/kontinuous/.github/actions/deploy-via-webhook@v1
@@ -42,7 +52,7 @@ jobs:
       - uses: socialgouv/workflows/actions/deployment-ending@v1
         id: deployment-ending
         with:
-          pat: ${{ secrets.SOCIALGROOVYBOT_BOTO_PAT }}
+          pat: ${{ steps.token.outputs.token }}
           token: ${{ secrets.GITHUB_TOKEN }}
           deployment-id: ${{ steps.deployment-starting.outputs.deployment-id }}
           deployment-name:

--- a/.github/workflows/use-ks-wh-review.yaml
+++ b/.github/workflows/use-ks-wh-review.yaml
@@ -12,6 +12,9 @@ on:
       KUBEWEBHOOK_TOKEN:
         required: true
 
+permissions:
+  id-token: write  # Required for OIDC token generation
+
 jobs:
   deploy:
     name: 🐳 Deploy Review on Kubernetes
@@ -20,11 +23,18 @@ jobs:
     outputs:
       manifests-images: ${{ steps.deployment-ending.outputs.manifests-images }}
     steps:
+      - name: Get GitHub App Token
+        id: token
+        uses: SocialGouv/token-bureau@main
+        with:
+          token-bureau-url: https://token-bureau.fabrique.social.gouv.fr
+          audience: socialgouv
+
       - uses: socialgouv/workflows/actions/deployment-starting@v1
         id: deployment-starting
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          pat: ${{ secrets.SOCIALGROOVYBOT_BOTO_PAT }}
+          pat: ${{ steps.token.outputs.token }}
           environment-scope: review
 
       - uses: socialgouv/kontinuous/.github/actions/deploy-via-webhook@v1
@@ -42,7 +52,7 @@ jobs:
       - uses: socialgouv/workflows/actions/deployment-ending@v1
         id: deployment-ending
         with:
-          pat: ${{ secrets.SOCIALGROOVYBOT_BOTO_PAT }}
+          pat: ${{ steps.token.outputs.token }}
           token: ${{ secrets.GITHUB_TOKEN }}
           deployment-id: ${{ steps.deployment-starting.outputs.deployment-id }}
           deployment-name:

--- a/.github/workflows/workflows-repository.sync-major-version-branch.yml
+++ b/.github/workflows/workflows-repository.sync-major-version-branch.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - 'v*.*.*'
 
+permissions:
+  id-token: write  # Required for OIDC token generation
+
 concurrency:
   cancel-in-progress: true
   group: sync-major-version-branch
@@ -13,17 +16,23 @@ jobs:
   sync:
     runs-on: ubuntu-latest
     steps:
-
       - name: Set vars
         id: vars
         run: |
           MAJOR_VERSION=$(echo "${GITHUB_REF#refs/*/}" | cut -d '.' -f 1)
           echo "major-version=$MAJOR_VERSION" >> $GITHUB_OUTPUT
       
+      - name: Get GitHub App Token
+        id: token
+        uses: SocialGouv/token-bureau@main
+        with:
+          token-bureau-url: https://token-bureau.fabrique.social.gouv.fr
+          audience: socialgouv
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.SOCIALGROOVYBOT_BOTO_PAT }}
+          token: ${{ steps.token.outputs.token }}
 
       - name: sync-major-version-branch
         uses: socialgouv/workflows/actions/release-deeplink-version@v1
@@ -33,8 +42,7 @@ jobs:
           GIT_COMMITTER_EMAIL: ${{ secrets.SOCIALGROOVYBOT_EMAIL }}
           GIT_COMMITTER_NAME: ${{ secrets.SOCIALGROOVYBOT_NAME }}
         with:
-          token: ${{ secrets.SOCIALGROOVYBOT_BOTO_PAT }}
-          # token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.token.outputs.token }}
           toolPath: socialgouv/workflows
           version: ${{ steps.vars.outputs.major-version }}
           branch: ${{ steps.vars.outputs.major-version }}

--- a/boilerplates/ks-gh/.github/workflows/release.yaml
+++ b/boilerplates/ks-gh/.github/workflows/release.yaml
@@ -3,13 +3,24 @@ on:
   workflow_dispatch:
   push:
     branches: [master, main, alpha, beta, next]
+
+permissions:
+  id-token: write  # Required for OIDC token generation
+
 jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
     steps:
-    - uses: socialgouv/workflows/actions/semantic-release@v1
-      with:
-        github-token: ${{ secrets.SOCIALGROOVYBOT_BOTO_PAT }}
-        author-name: ${{ secrets.SOCIALGROOVYBOT_NAME }}
-        author-email: ${{ secrets.SOCIALGROOVYBOT_EMAIL }}
+      - name: Get GitHub App Token
+        id: token
+        uses: SocialGouv/token-bureau@main
+        with:
+          token-bureau-url: https://token-bureau.fabrique.social.gouv.fr
+          audience: socialgouv
+
+      - uses: socialgouv/workflows/actions/semantic-release@v1
+        with:
+          github-token: ${{ steps.token.outputs.token }}
+          author-name: ${{ secrets.SOCIALGROOVYBOT_NAME }}
+          author-email: ${{ secrets.SOCIALGROOVYBOT_EMAIL }}

--- a/boilerplates/ks-wh/.github/workflows/release.yaml
+++ b/boilerplates/ks-wh/.github/workflows/release.yaml
@@ -3,13 +3,24 @@ on:
   workflow_dispatch:
   push:
     branches: [master, main, alpha, beta, next]
+
+permissions:
+  id-token: write  # Required for OIDC token generation
+
 jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
     steps:
-    - uses: socialgouv/workflows/actions/semantic-release@v1
-      with:
-        github-token: ${{ secrets.SOCIALGROOVYBOT_BOTO_PAT }}
-        author-name: ${{ secrets.SOCIALGROOVYBOT_NAME }}
-        author-email: ${{ secrets.SOCIALGROOVYBOT_EMAIL }}
+      - name: Get GitHub App Token
+        id: token
+        uses: SocialGouv/token-bureau@main
+        with:
+          token-bureau-url: https://token-bureau.fabrique.social.gouv.fr
+          audience: socialgouv
+
+      - uses: socialgouv/workflows/actions/semantic-release@v1
+        with:
+          github-token: ${{ steps.token.outputs.token }}
+          author-name: ${{ secrets.SOCIALGROOVYBOT_NAME }}
+          author-email: ${{ secrets.SOCIALGROOVYBOT_EMAIL }}


### PR DESCRIPTION
Migration vers le nouveau système "TokenBureau", le SOCIALGROOVYBOT_BOTO_PAT ne sera plus disponible à partir de février 2025, si vous voulez que vos workflows continuent à fonctionner correctement, vous devez merger cette PR.